### PR TITLE
refactor(db): use default node-postgres env vars, allow dev to config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# reflect
+# Reflect
+
+## Developing locally
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org)
+- [Yarn](https://yarnpkg.com)
+- [PostgreSQL](https://www.postgresql.org)
+
+### Environment
+
+Add a `.env` file in the root of the project. You will need to add config for connecting to PostgresSQL, there is information on how to configure the client library [here](https://node-postgres.com/features/connecting#environment-variables). If you are running PostgreSQL locally with the default settings you will probably only need to set `PGUSER` and `PGPASSWORD`.
+
+### Installing dependencies
+
+Just run `yarn` in the root of the project.
+
+### Scripts
+
+For a list of all scripts see the `scripts` field in the [package.json](package.json).

--- a/src/api/database.js
+++ b/src/api/database.js
@@ -1,9 +1,3 @@
 const { Pool } = require('pg');
 
-module.exports = new Pool({
-  host: process.env.DB_HOST,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  port: 5432,
-  database: 'reflect',
-});
+module.exports = new Pool({ database: 'reflect' });


### PR DESCRIPTION
…ure pg port and add some documentation for getting started

Mostly raised this so I can configure the db port. But also nice to have some developer documentation. Unfortunately this info alone isn't enough to get the app running yet :D